### PR TITLE
Adminpanel:Collection now display as a number

### DIFF
--- a/app/helpers/adminpanel/shared_pages_helper.rb
+++ b/app/helpers/adminpanel/shared_pages_helper.rb
@@ -76,6 +76,8 @@ module Adminpanel
         end
       when 'enum_field'
         I18n.t("#{object.class.name.demodulize.downcase}.#{object.send(attribute)}")
+      when 'adminpanel_file_field'
+        object.send(attribute)
       else
         object.send(attribute)
       end

--- a/app/helpers/adminpanel/shared_pages_helper.rb
+++ b/app/helpers/adminpanel/shared_pages_helper.rb
@@ -77,7 +77,7 @@ module Adminpanel
       when 'enum_field'
         I18n.t("#{object.class.name.demodulize.downcase}.#{object.send(attribute)}")
       when 'adminpanel_file_field'
-        object.send(attribute)
+        object.send(attribute).count
       else
         object.send(attribute)
       end


### PR DESCRIPTION
When creating an Adminpanel::gallery into a resource, the resource was showing the object address. Now it displays the total of items in the collection.