### PR TITLE
Change the way select generates the collection

### DIFF
--- a/app/models/adminpanel/permission.rb
+++ b/app/models/adminpanel/permission.rb
@@ -28,9 +28,7 @@ module Adminpanel
           'role_id' => {
             'type' => 'select',
             'label' => I18n.t('permission.role'),
-            'options' => Proc.new {|object|
-              Adminpanel::Role.all.map {|o| [o.id, o.name]}
-            }
+            'options' => Proc.new {|object| Adminpanel::Role.all }
           }
         },
         {

--- a/app/views/adminpanel/form/_select.html.erb
+++ b/app/views/adminpanel/form/_select.html.erb
@@ -3,18 +3,18 @@
   args = properties.except('options')
   collection = block.call(f.object)
   if collection.class.to_s.demodulize == 'ActiveRecord_Relation'
-    id_method = :id
-    label_method = :name
-  else
-    id_method = :first
-    label_method = :last
+    properties['id_method'] ||= :id
+    properties['name_method'] ||= :name
+    collection = options_from_collection_for_select(
+                    collection,
+                    properties['id_method'],
+                    properties['name_method'],
+                    @resource_instance.send(attribute)
+                  )
+
+  elsif ['Hash', 'Array', 'HashWithIndifferentAccess'].include? collection.class.to_s.demodulize
+    collection = options_for_select(collection)
   end
-  collection = options_from_collection_for_select(
-                  collection,
-                  id_method,
-                  label_method,
-                  @resource_instance.send(attribute)
-                )
 %>
 <%= f.select attribute, collection, { include_blank: true }, args  %>
 

--- a/test/dummy/app/models/adminpanel/salesman.rb
+++ b/test/dummy/app/models/adminpanel/salesman.rb
@@ -19,9 +19,8 @@ module Adminpanel
           'product_id' => {
             'type' => 'select',
             'label' => 'product_id',
-            'options' => Proc.new { |object|
-              Adminpanel::Product.all.map {|o| [o.id, o.supername]}
-            }
+            'options' => Proc.new { |object| Adminpanel::Product.all },
+            'name_method' => :supername
           }
         },
       ]

--- a/test/features/shared/form/select_test.rb
+++ b/test/features/shared/form/select_test.rb
@@ -23,15 +23,14 @@ class SelectTest < ViewCase
     assert select_selector.find('option', text: 'Publisher')
   end
 
-  def test_select_with_mapped_result
-    # test select, with proc in options gives an
-    # [['one', '1'], ['two', '2'], ...] as a repsonse (map)
+  def test_select_with_diffent_name_method
+    # test select, with a name method different than the default
     visit adminpanel.new_salesman_path
     # puts page.
     select_field = find('#salesman_product_id')
     assert select_field
-    assert select_field.find('option', text: 'SuperProduct saved')
-    assert select_field.find('option', text: 'SuperProduct with limit')
+    assert select_field.find('option', text: adminpanel_products(:first).supername)
+    assert select_field.find('option', text: adminpanel_products(:limit_images).supername)
   end
 
   private


### PR DESCRIPTION
Now we can send an array, hash or hash with indiffent access in the proc evaluation for the select options, also we can specify the name_method and the id_method for the collection.